### PR TITLE
fix filter_fasta

### DIFF
--- a/pavfinder/scripts/filter_fasta
+++ b/pavfinder/scripts/filter_fasta
@@ -1,6 +1,4 @@
-#!/bin/sh
-# Exec script with awk. Don't remove slash \
-exec awk -f "$0" "$@"
+#!/usr/bin/env -S awk -f
 
 !/^>/ { next }
 { getline seq }


### PR DESCRIPTION
Sorry about the mess up with `filter_fasta`. Comments in `awk` do not work as I thought. This solution uses `env` to find `awk` in the path.